### PR TITLE
Add Regularization

### DIFF
--- a/OAI/config.py
+++ b/OAI/config.py
@@ -3,7 +3,7 @@ import os
 
 MODEL_NAME = 'resnet18'
 N_DATALOADER_WORKERS = 2
-CACHE_LIMIT = 1e8
+CACHE_LIMIT = 500
 EST_TIME_PER_EXP = 4
 BASE_DIR = ''
 DATA_DIR = '/juice/scr/oai/'

--- a/OAI/models.py
+++ b/OAI/models.py
@@ -656,6 +656,7 @@ class ModelXtoYWithAuxC(InterventionModelOnC, ModelXtoCY):
         # latent fc layer
         C_fc_size = self.fc_layers[int(self.C_fc_name[2:]) - 1]
         latent_size = C_fc_size - len(self.C_cols)
+        assert latent_size > 0
         self.fc_latent = nn.Linear(latent_size, latent_size)
 
         self.build()

--- a/OAI/train.py
+++ b/OAI/train.py
@@ -499,7 +499,6 @@ def generate_configs(args):
             'lr': 0.0005
         },
         'optimizer_name': 'adam',
-        'latent_reg': None,
         'pretrained_path': None,
         'pretrained_model_name': 'resnet18',
         'scheduler_kwargs': {

--- a/OAI/train.py
+++ b/OAI/train.py
@@ -219,7 +219,7 @@ def save_model_results(model, results, args, dataset_kwargs, model_kwargs, exp_n
         dest_file = os.path.join(dest_code_dir, model_code_file)
         os.system('cp %s %s' % (src_file, dest_file))
     # Dataset code
-    src_file = os.path.join(BASE_DIR, 'dataset.py')
+    src_file = os.path.join(BASE_DIR, 'OAI', 'dataset.py')
     dest_file = os.path.join(dest_code_dir, 'dataset.py')
     os.system('cp %s %s' % (src_file, dest_file))
 
@@ -499,6 +499,7 @@ def generate_configs(args):
             'lr': 0.0005
         },
         'optimizer_name': 'adam',
+        'latent_reg': None,
         'pretrained_path': None,
         'pretrained_model_name': 'resnet18',
         'scheduler_kwargs': {
@@ -585,6 +586,7 @@ def generate_configs(args):
 
     elif experiment_name == 'StandardWithAuxC':
         assert y_dims == args.fc_layers[fc_layer_y], print(y_dims, args.fc_layers[fc_layer_y])
+        # assert C_dims == 0.5 * args.fc_layers[fc_layer_C], print(C_dims, args.fc_layers[fc_layer_C])
 
     elif experiment_name == 'Multitask':
         # model_kwargs['fc_layers'] = [N_concepts + 1]
@@ -624,6 +626,9 @@ def generate_configs(args):
         kwargs['gamma'] = 0.5
     else:
         raise Exception('Unknown scheduler: %s' % args.lr_scheduler)
+
+    # Set latent regularization parameter
+    model_kwargs['latent_reg'] = args.latent_reg
 
     # Different sampling weights according to the sample's C and y
     if args.sampling in ['weigh_C', 'weigh_Cy']:
@@ -707,6 +712,7 @@ def parse_arguments(experiment):
     parser.add_argument('--lr', type=float, default=0.0005, help='Learning rate.')
     parser.add_argument('--lr_scheduler', default='step', choices=['plateau', 'step'],
                         help='Learning rate scheduler for training.')
+    parser.add_argument('--latent_reg', type=float, default=0, help='Regularization for gate units in C layer')
 
     # ---- Loading of Pretrained Models ----
     parser.add_argument('--pretrained', type=str, nargs='+', default=None, help='Pretrained model path.')


### PR DESCRIPTION
# Command: 

```
python experiments.py oai StandardWithAuxC --use_small_subset --seed 1 --fc_layers 15 50 1 --C_fc_name fc1 --y_fc_name fc3 --num_epochs=2 --latent_reg 0.5
```

(currently still keeps all 10 concepts)

# Strategy:

The concept FC layer has 15, aka 5 more units than the 10 concepts. the remaining 5 are gate nodes.

These 5 undergo another FC layer (`fc_latent`) which has regularized weights. The latent nodes undergo two rounds of RELU, while concepts undergo no RELU.

After the extra FC, the concepts and latent nodes are concat'd for the next FC layer (50).